### PR TITLE
Mod ssl setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ If you require assistance with these labs, contact Northwest Cadence through our
     
     Simply click the Deploy to Azure button below and follow the wizard to create the resources. You will need to log in to the Azure Portal.
                                                                      
-	<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fnwcadence%2Fjava-dev-vsts%2FModSSLSetup%2Fenv%2FJavaDevVSTS.json" target="_blank">
+	<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fnwcadence%2Fjava-dev-vsts%2Fmaster%2Fenv%2FJavaDevVSTS.json" target="_blank">
 		<img src="http://azuredeploy.net/deploybutton.png"/>
 	</a>
-	<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2Fnwcadence%2Fjava-dev-vsts%2FModSSLSetup%2Fenv%2FJavaDevVSTS.json" target="_blank">
+	<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2Fnwcadence%2Fjava-dev-vsts%2Fmaster%2Fenv%2FJavaDevVSTS.json" target="_blank">
 		<img src="http://armviz.io/visualizebutton.png"/>
 	</a>
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ If you require assistance with these labs, contact Northwest Cadence through our
     
     Simply click the Deploy to Azure button below and follow the wizard to create the resources. You will need to log in to the Azure Portal.
                                                                      
-	<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fnwcadence%2Fjava-dev-vsts%2Fmaster%2Fenv%2FJavaDevVSTS.json" target="_blank">
+	<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fnwcadence%2Fjava-dev-vsts%2FModSSLSetup%2Fenv%2FJavaDevVSTS.json" target="_blank">
 		<img src="http://azuredeploy.net/deploybutton.png"/>
 	</a>
-	<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2Fnwcadence%2Fjava-dev-vsts%2Fmaster%2Fenv%2FJavaDevVSTS.json" target="_blank">
+	<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2Fnwcadence%2Fjava-dev-vsts%2FModSSLSetup%2Fenv%2FJavaDevVSTS.json" target="_blank">
 		<img src="http://armviz.io/visualizebutton.png"/>
 	</a>
 

--- a/env/configure-java-vm.sh
+++ b/env/configure-java-vm.sh
@@ -239,7 +239,7 @@ openssl genrsa \
   -out server-key.pem $STR
 
 openssl req \
-  -subj "/CN=$HOSTNAME.$azureregion.cloudapp.azure.com" \
+  -subj "/CN=$HOSTNAME" \
   -new \
   -key server-key.pem \
   -out server.csr
@@ -292,7 +292,7 @@ sed -e "s/-H fd:\/\///g" -i /lib/systemd/system/docker.service
 systemctl daemon-reload
 
 # set default environment variables
-echo "export DOCKER_HOST=tcp://$HOSTNAME.$azureregion.cloudapp.azure.com:2376" >> /home/$username/.profile
+echo "export DOCKER_HOST=tcp://$HOSTNAME:2376" >> /home/$username/.profile
 echo "export DOCKER_TLS_VERIFY=1" >> /home/$username/.profile
 
 popd

--- a/env/configure-java-vm.sh
+++ b/env/configure-java-vm.sh
@@ -244,7 +244,7 @@ openssl req \
   -key server-key.pem \
   -out server.csr
 
-echo "subjectAltName = DNS:$HOSTNAME.$azureregion.cloudapp.azure.com,IP:127.0.0.1,IP:10.0.0.4" > extfile.cnf
+echo "subjectAltName = DNS:$HOSTNAME.$azureregion.cloudapp.azure.com,DNS:$HOSTNAME,IP:127.0.0.1,IP:10.0.0.4" > extfile.cnf
 openssl x509 \
   -req \
   -days 3650 \


### PR DESCRIPTION
The docker hosts needed to bind to the nic IP ($HOSTNAME) vs the external IP (FQDN).

Doing that would break the SSL certificate for VSTS, so we ended up adding an additional entry to the SSL cert Subj Alt Name list (the cert is valid for both the internal and external addresses now).
